### PR TITLE
Build compatibility for later versions of node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,111 +1,19 @@
-INFO
-----
+This is a fork of the [gzbz2](https://github.com/Woodya/node-gzbz2) NodeJS module (provides gzip and bzip2 (de)compression), updated to work on newer versions of NodeJS (should support 0.10.x to 12.x.x which probably includes 15.x.x) and fixed libbz2 linking.
 
-gzbz2 - A Node.js interface to streaming gzip/bzip2 compression (built originally from wave.to/node-compress)
+### Installation
 
-supports Buffe or string as both input and output, this is controlled by providing encodings to init (to produce Buffers), or by passing whichever you are using as input (with optional encoding for strings).
-Bzip and Gzip have the same interfaces, see Versions for specific options info. Also there are two simple js wrappers for producing usable read streams, gunzipstream.js and bunzipstream.js. 
+You’ll need development headers/stubs installed for libz (zlib) and libbz2 for the module to compile.
 
-INSTALL
--------
+Then use the following command:
 
-To install, ensure that you have libz (and libbz2) installed:
-* these will be looked for in: /usr/lib, /usr/local/lib, /opt/local/lib (on osx)
+```bash
+npm install https://github.com/animetosho/node-gzbz2
+```
 
-npm install gzbz2
+### Examples & Credits
 
-or
+See [original README](https://github.com/Woodya/node-gzbz2/blob/master/README.md)
 
-waf way: node-waf configure [--no-bzip] [--no-gzip]
+**Warning**: incorrect usage may result in NodeJS crashing!
+I haven’t bothered to fix this issue (grandfathered from the original module), but it usually shouldn’t be a problem.
 
-gyp way: node-gype configure  (no idea how to conditionally configure..)
-
-node-gyp build
-
-Note: on osx, you must run node-waf with python2.6 or greater for configure to work properly. (unsure if this applies to node-gyp)
-
-Quick Gzip example
-------------------
-
-    var gzbz2 = require("gzbz2");
-    var util = require("util");
-
-    // Create gzip stream
-    var gzip = new gzbz2.Gzip;
-    // binary string output
-    // init also accepts level: [0-9]
-    gzip.init({encoding: 'binary'});
-
-    // Pump data to be compressed
-    var gzdata1 = gzip.deflate("My data that needs ", "ascii");
-    util.puts("Compressed size : "+gzdata1.length);
-
-    // treat string as binary encoded
-    var gzdata2 = gzip.deflate("to be compressed. 01234567890.");
-    util.puts("Compressed size : "+gzdata2.length);
-
-    var gzdata3 = gzip.end(); // important to capture end data
-    util.puts("Last bit : "+gzdata3.length);
-
-    // Normally stream this out as its generated, but just print here
-    var gzdata = gzdata1+gzdata2+gzdata3;
-    util.puts("Total compressed size : "+gzdata.length);
-
-Quick Gunzip example
---------------------
-
-    var gzbz2 = require("gzbz2");
-    var fs = require("fs");
-
-    var gunzip = new gzbz2.Gunzip;
-    gunzip.init({encoding: "utf8"});
-
-    var gzdata = fs.readFileSync("somefile.gz", "binary");
-    var inflated = gunzip.inflate(gzdata, "binary");
-    gunzip.end(); // returns nothing
-
-Quick Gunzip Stream example
----------------------------
-    var fs = require('fs'),
-        gunzip = require('gzbz2/gunzipstream');
-    
-    var stream = gunzip.wrap(process.argv[2], {encoding: process.argv[3]});
-    stream.on('data', function(data) {
-        process.stdout.write(data);
-    });
-    stream.on('end', function() {
-        process.exit(0);
-    });
-
-Versions
---------
-
-* 0.2.0:
-    * added ripcurld00d's updates for node-gyp & node\_event.h removal
-* 0.1.\*:
-    * added bzip2 support. same interface. Bzip/Bunzip objects, bzip specific init options
-        * bzip.init
-            * encoding (the output encoding, undefined/null means Buffers)
-            * level [1-9], 1 fastest (least memory), 9 slowest (most memory), default = 1
-            * workfactor [0-250], read libbz2 docs, default = 30
-        * bunzip.init
-            * encoding (the output encoding, undefined/null means Buffers)
-            * small (boolean[false]) deflate in slow but small memory mode, default = false
-    * buffer capable (on by default, this changes the default api use)
-        * buffer input inflate/deflate always allowed, buffer output from same is the default
-    * init accepts options object to configure buffer behavior, compression, and inflated encoding etc:
-        * Gzip.init({encoding: enc, level: [0-9]}), level controls compression level 0 = none, 1 = lowest etc.
-        * Gunzip.init({encoding: enc})
-        * if an encoding is provided to init(), then the output of inflate/deflate will be a string
-        * when providing encodings (either for input our output) for binary data, 'binary' is the only viable encoding, as base64 is not currenlty supported
-    * inflate accepts a buffer or binary string[+encoding[default = 'binary']], output will be a buffer or a string encoded according to init options
-    * deflate accepts a buffer or string[+encoding[default = 'utf8']], output will be a buffer or a string encoded according to init options
-    * also added two submodules gunzipstream, and bunzipstream
-        * use these to quickly/easily decompress a file while writing similar code to regular input streams
-* 0.0.\*:
-    * all string based, encodings in inflate/deflate methods, no init params
-
-Authors
--------
-* wave.to: developer of node-compress aka 0.0.1 version and the general framework
-* woody.anderson@gmail.com, fixed bugs/memory leaks, added 0.1.\* features: buffers, bzip2, npm as gzbz2, 

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,11 @@
       'libraries': ['-L/usr/lib', '-L/usr/local/lib'],
       'target_name': 'gzbz2',
       'sources': ['compress.cc'],
+      'link_settings': {
+        'libraries': [
+          '-lbz2'
+        ]
+      },
       'conditions': [
         ['OS=="linux"',
           {

--- a/buffer_compat.h
+++ b/buffer_compat.h
@@ -6,7 +6,7 @@
 #include <node_version.h>
 #include <v8.h>
 
-#if NODE_MINOR_VERSION < 3
+#if NODE_MINOR_VERSION < 3 && NODE_MAJOR_VERSION < 1
 
 char *BufferData(node::Buffer *b) {
     return b->data();
@@ -25,7 +25,7 @@ size_t BufferLength(v8::Local<v8::Object> buf_obj) {
     return buf->length();
 }
 
-#else // NODE_VERSION
+#elif NODE_MAJOR_VERSION < 3
 
 char *BufferData(node::Buffer *b) {
     return node::Buffer::Data(b->handle_);
@@ -41,6 +41,11 @@ size_t BufferLength(v8::Local<v8::Object> buf_obj) {
     v8::HandleScope scope;
     return node::Buffer::Length(buf_obj);
 }
+
+#else // NODE_VERSION
+
+#define BufferData node::Buffer::Data
+#define BufferLength node::Buffer::Length
 
 #endif // NODE_VERSION
 

--- a/test.js
+++ b/test.js
@@ -8,35 +8,40 @@ var enc = process.argv[3];
 var data = fs.readFileSync(testfile, enc);
 console.log("Got : " + data.length);
 
-// Set output file
-var fd = fs.openSync(testfile + ".gz", "w", 0644);
-console.log("File opened");
-
-// Create gzip stream
-var gzip = new gzbz2.Gzip;
-gzip.init({level:3});
-
-// Pump data to be gzbz2
-var gzdata = gzip.deflate(data, enc);  // Do this as many times as required
-console.log("Compressed chunk size : " + gzdata.length);
-fs.writeSync(fd, gzdata, 0, gzdata.length, null);
-
-// Get the last bit
-var gzlast = gzip.end();
-console.log("Compressed chunk size: " + gzlast.length);
-fs.writeSync(fd, gzlast, 0, gzlast.length, null);
-fs.closeSync(fd);
-console.log("File closed");
-
-// See if we can uncompress it ok
-var gunzip = new gzbz2.Gunzip;
-gunzip.init({encoding: enc});
-var testdata = fs.readFileSync(testfile + ".gz");
-console.log("Test opened : " + testdata.length);
-var inflated = gunzip.inflate(testdata, enc);
-console.log("GZ.inflate.length: " + inflated.length);
-gunzip.end(); // no return value
-
-if (data.length != inflated.length) {
-    console.log('error! input/output string lengths do not match');
-}
+["G", "B"].forEach(function(type) {
+    console.log("Testing " + type + "zip...");
+    var output = testfile + "." + (type == "G" ? "gz" : "bz2");
+    
+    // Set output file
+    var fd = fs.openSync(output, "w", 0644);
+    console.log("File opened");
+    
+    // Create zip stream
+    var zip = new gzbz2[type + "zip"];
+    zip.init({level:3});
+    
+    // Pump data to be gzbz2
+    var zdata = zip.deflate(data, enc);  // Do this as many times as required
+    console.log("Compressed chunk size : " + zdata.length);
+    fs.writeSync(fd, zdata, 0, zdata.length, null);
+    
+    // Get the last bit
+    var zlast = zip.end();
+    console.log("Compressed chunk size: " + zlast.length);
+    fs.writeSync(fd, zlast, 0, zlast.length, null);
+    fs.closeSync(fd);
+    console.log("File closed");
+    
+    // See if we can uncompress it ok
+    var unzip = new gzbz2[type + "unzip"];
+    unzip.init({encoding: enc});
+    var testdata = fs.readFileSync(output);
+    console.log("Test opened : " + testdata.length);
+    var inflated = unzip.inflate(testdata, enc);
+    console.log(type + "Z.inflate.length: " + inflated.length);
+    unzip.end(); // no return value
+    
+    if (data.length != inflated.length) {
+        console.log('error! input/output string lengths do not match');
+    }
+});

--- a/test.js
+++ b/test.js
@@ -6,11 +6,11 @@ var fs = require("fs");
 var testfile = process.argv[2] || "test.js";
 var enc = process.argv[3];
 var data = fs.readFileSync(testfile, enc);
-util.puts("Got : " + data.length);
+console.log("Got : " + data.length);
 
 // Set output file
 var fd = fs.openSync(testfile + ".gz", "w", 0644);
-util.puts("File opened");
+console.log("File opened");
 
 // Create gzip stream
 var gzip = new gzbz2.Gzip;
@@ -18,25 +18,25 @@ gzip.init({level:3});
 
 // Pump data to be gzbz2
 var gzdata = gzip.deflate(data, enc);  // Do this as many times as required
-util.puts("Compressed chunk size : " + gzdata.length);
+console.log("Compressed chunk size : " + gzdata.length);
 fs.writeSync(fd, gzdata, 0, gzdata.length, null);
 
 // Get the last bit
 var gzlast = gzip.end();
-util.puts("Compressed chunk size: " + gzlast.length);
+console.log("Compressed chunk size: " + gzlast.length);
 fs.writeSync(fd, gzlast, 0, gzlast.length, null);
 fs.closeSync(fd);
-util.puts("File closed");
+console.log("File closed");
 
 // See if we can uncompress it ok
 var gunzip = new gzbz2.Gunzip;
 gunzip.init({encoding: enc});
 var testdata = fs.readFileSync(testfile + ".gz");
-util.puts("Test opened : " + testdata.length);
+console.log("Test opened : " + testdata.length);
 var inflated = gunzip.inflate(testdata, enc);
-util.puts("GZ.inflate.length: " + inflated.length);
+console.log("GZ.inflate.length: " + inflated.length);
 gunzip.end(); // no return value
 
 if (data.length != inflated.length) {
-    util.puts('error! input/output string lengths do not match');
+    console.log('error! input/output string lengths do not match');
 }


### PR DESCRIPTION
node-gzbz2 compiles on Node up to version 0.10.x, but the V8 API was significantly changed in 0.12.x and it won't compile on later versions of Node.

I've made some changes and it now compiles on Node version 4.x and presumably later versions. I haven't tested this on version 0.12.x or similar. Changes perhaps aren't the neatest, but it's hopefully better than not working at all.

I've also taken the liberty to fix up bzip2, as it wasn't linked in the gyp file.